### PR TITLE
lower Compat requirement to 0.7.16

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -4,4 +4,4 @@ ColorTypes 0.1
 Images     0.4
 Interpolations   0.3
 PyPlot     2.0
-Compat     0.9
+Compat     0.7.16


### PR DESCRIPTION
Pkg upgrades to the latest versions it can by default, lower version bounds aren't for recording "this is what I tested with" they're for recording "this is the lowest version that could work correctly." If all you're using Compat for is Compat.ASCIIString (https://github.com/JuliaLang/METADATA.jl/pull/8653#discussion_r111281608), that was introduced in 0.7.16. https://github.com/JuliaLang/Compat.jl/commit/7c85f0c9d7b097d25c149d63e2a13ea647c13b48