### PR TITLE
Update from REQUIRE to Project.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *~
 *#
 *.DS_Store
+Manifest.toml

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ os:
 julia:
   - 0.7
   - 1.0
+  - 1.1
+  - 1.2
+  - 1.3
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ git:
 matrix:
   allow_failures:
   - julia: nightly
-script:
-  - julia -e 'using Pkg; Pkg.clone(pwd()); ENV["PYTHON"]=""; Pkg.build("PyCall"); Pkg.build("PerceptualColourMaps"); Pkg.test("PerceptualColourMaps"; coverage=true)'
+env:
+  PYTHON=

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,29 @@
+name = "PerceptualColourMaps"
+uuid = "54e51dfa-9dd7-5231-aa84-a4037b83483a"
+version = "0.3.1"
+
+[deps]
+ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
+Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[compat]
+ColorTypes = "≥ 0.3.4"
+Colors = "≥ 0.7.3"
+Images = "≥ 0.9.1"
+Interpolations = "≥ 0.9"
+PyPlot = "≥ 2.3.0"
+julia = "0.7, 1"
+
+[extras]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Statistics", "LinearAlgebra", "Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,0 @@
-julia      0.7
-Colors     0.7.3
-ColorTypes 0.3.4
-Images     0.9.1
-Interpolations   0.9
-PyPlot     2.3.0


### PR DESCRIPTION
Currently the last version of this package available in the [General](https://github.com/JuliaRegistries/General) registry is 0.3.0, not the latest 0.3.1. And it looks like the project needs to have a Project.toml instead of a REQUIRE file in order to be updated. So here is a PR which does the conversion, using [gen_project.jl](https://github.com/JuliaLang/Pkg.jl/blob/934f8b71eb436da6d2bdb30ccfc80e5e11891c5b/bin/gen_project.jl) as described in [Creating Packages](https://julialang.github.io/Pkg.jl/v1/creating-packages/).

I'm not sure how to best handle the version constraints in `[compat]`, though. The way they are now, without an upper bound, will forbid [a simplified workflow](https://github.com/JuliaRegistries/General#automatic-merging-of-pull-requests) for pushing future updates to the registry and generally seems to have caused some trouble in the ecosystem. But setting overly tight bounds on 0.X packages, which are the majority, is bad too. That's a hot topic, see the discussion [here](https://discourse.julialang.org/t/please-be-mindful-of-version-bounds-and-semantic-versioning-when-tagging-your-packages/30708) for example. I think the middle ground could be to go with "^2.3.0" for PyPlot, i.e. [2.3.0 <= v < 3.0.0](https://julialang.github.io/Pkg.jl/v1/compatibility/#Caret-specifiers-1), but only restrict the 0.X packages to "^0", i.e. all pre-1.0 versions, and be ready to handle *some* changes in them. Also, given all this trouble with 0.X, you might want to make a 1.0 release of this package if you don't anticipate any big changes.