### PR TITLE
Update for more recent package versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,8 @@
 name = "PerceptualColourMaps"
 uuid = "54e51dfa-9dd7-5231-aa84-a4037b83483a"
-version = "0.3.2"
+version = "0.3.3"
 
 [deps]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 Colors = "5ae59095-9a9b-59fe-a467-6f913c188581"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
@@ -13,11 +12,10 @@ PyPlot = "d330b81b-6aea-500a-939a-2ce795aea3ee"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ColorTypes = "≥ 0.3.4"
-Colors = "≥ 0.7.3"
-Images = "≥ 0.9.1"
-Interpolations = "≥ 0.9"
-PyPlot = "≥ 2.3.0"
+Colors = "0.9.6, 0.10, 0.11, 0.12"
+Images = "0.16, 0.17, 0.18, 0.19, 0.20, 0.21, 0.22"
+Interpolations = "0.9, 0.10, 0.11, 0.12"
+PyPlot = "2.3"
 julia = "0.7, 1"
 
 [extras]

--- a/src/applycolourmaps.jl
+++ b/src/applycolourmaps.jl
@@ -14,7 +14,8 @@ The Software is provided "as is", without warranty of any kind.
 
 ----------------------------------------------------------------------------=#
 
-import ColorTypes, Images
+import Images
+import Images.ColorTypes
 
 export applycolourmap, applydivergingcolourmap, applycycliccolourmap, ternaryimage
 export applycolormap, applydivergingcolormap, applycycliccolormap
@@ -107,7 +108,7 @@ end
 
 # Case for img::ImageMeta
 function applycolourmap(img::ImageMeta{T,2}, cmap, rnge) where T
-    rgbimg = applycolourmap(float(Images.data(img)), cmap, rnge)
+    rgbimg = applycolourmap(float(Images.arraydata(img)), cmap, rnge)
     return ImageMeta(rgbimg, colordim = 3, colorspace=Images.RGB,
                         spatialorder = img.properties["spatialorder"])
 end
@@ -155,7 +156,7 @@ end
 
 # Case for img::ImageMeta
 function applycolormap(img::ImageMeta{T,2}, cmap, rnge) where T
-    rgbimg = applycolourmap(float(Images.data(img)), cmap, rnge)
+    rgbimg = applycolourmap(float(Images.arraydata(img)), cmap, rnge)
     return ImageMeta(rgbimg, colordim = 3, colorspace=Images.RGB,
                      spatialorder = img.properties["spatialorder"])
 end
@@ -250,7 +251,7 @@ end
 function ternaryimage(img::ImageMeta{T,3};
                       bands::Array = [1, 2, 3], histcut::Real = 0.0, RGB::Bool=false) where T
 
-    rgbimg = ternaryimage(float(Images.data(img)), bands=bands, histcut=histcut, RGB=RGB)
+    rgbimg = ternaryimage(float(Images.arraydata(img)), bands=bands, histcut=histcut, RGB=RGB)
     return ImageMeta(rgbimg, colordim = 3, colorspace=Images.RGB, spatialorder = img.properties["spatialorder"])
 end
 
@@ -343,7 +344,7 @@ end
 function applycycliccolourmap(img::ImageMeta{T1,2}, cmap::Array{ColorTypes.RGBA{Float64},1};
                           amp::ImageMeta{T2,2}=ImageMeta(Array{Float64}(undef, 0,0)),
                           cyclelength::Real=2*pi, modtoblack::Bool=true) where {T1,T2}
-    rgbimg = applycycliccolourmap(float(Images.data(img)), cmap, amp=float(Images.data(amp)),
+    rgbimg = applycycliccolourmap(float(Images.arraydata(img)), cmap, amp=float(Images.arraydata(amp)),
                    cyclelength=cyclelength, modtoblack=modtoblack)
     return ImageMeta(rgbimg, colordim = 3, colorspace=Images.RGB, spatialorder = img.properties["spatialorder"])
 end

--- a/src/cmap.jl
+++ b/src/cmap.jl
@@ -19,7 +19,8 @@ export lab2srgb, srgb2lab, RGBA2UInt32
 export RGB2FloatArray, RGBA2FloatArray
 export FloatArray2RGB, FloatArray2RGBA
 
-import Colors, ColorTypes, PyPlot
+import Images, PyPlot
+import Images.ColorTypes, Images.Colors
 using Interpolations
 
 # There seems to be a fatal clash between PyPlot and Tk.  ImageView
@@ -2410,15 +2411,15 @@ function ciede2000(L::Array, a::Array, b::Array, W::Array)
 
     # Compute deltaE using central differences
     for i = 2:N-1
-        deltaE[i] = Colors.colordiff(Colors.Lab(L[i+1],a[i+1],b[i+1]), Colors.Lab(L[i-1],a[i-1],b[i-1]),
-                                     Colors.DE_2000(kl,kc,kh))/2
+        deltaE[i] = Colors.colordiff(Colors.Lab(L[i+1],a[i+1],b[i+1]), Colors.Lab(L[i-1],a[i-1],b[i-1]);
+                                     metric=Colors.DE_2000(kl,kc,kh))/2
     end
 
     # Differences at end points
-    deltaE[1] = Colors.colordiff(Colors.Lab(L[2],a[2],b[2]), Colors.Lab(L[1],a[1],b[1]),
-                                  Colors.DE_2000(kl,kc,kh))
-    deltaE[N] = Colors.colordiff(Colors.Lab(L[N],a[N],b[N]), Colors.Lab(L[N-1],a[N-1],b[N-1]),
-                                  Colors.DE_2000(kl,kc,kh))
+    deltaE[1] = Colors.colordiff(Colors.Lab(L[2],a[2],b[2]), Colors.Lab(L[1],a[1],b[1]);
+                                 metric = Colors.DE_2000(kl,kc,kh))
+    deltaE[N] = Colors.colordiff(Colors.Lab(L[N],a[N],b[N]), Colors.Lab(L[N-1],a[N-1],b[N-1]);
+                                 metric=Colors.DE_2000(kl,kc,kh))
 
     return deltaE
 end


### PR DESCRIPTION
This also:
- adds upper bounds on [compat], which is needed for automatic merging
- eliminates the explicit ColorTypes dependency, to reduce the need to
  update the [compat]. You get ColorTypes via Colors & Images.
  Once there's a released version of Images that requires at least
  v0.9.6 of Colors, you could lower-bound Images and then drop Colors
  as an explicit dependency.